### PR TITLE
Add Spring Boot + React todo app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# codex-test-vv
+# Todo Web Application
+
+This repository contains a simple Todo application with a Spring Boot backend and a React-based frontend.
+
+## Backend
+
+The backend is located in the `backend` directory and is a Maven-based Spring Boot project.
+
+### Build & Run
+
+```bash
+cd backend
+mvn spring-boot:run
+```
+
+The application will start on port `8080` and exposes REST endpoints under `/api/todos`.
+
+## Frontend
+
+A minimal React application is provided in the `frontend` directory. No build step is required.
+Open `frontend/index.html` in your browser while the backend is running to interact with the API.
+
+## Features
+
+- Add, update, delete and list todos
+- Persistence with an in-memory H2 database
+- Simple web interface using React and Axios

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>todo</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.1</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/src/main/java/com/example/todo/TodoApplication.java
+++ b/backend/src/main/java/com/example/todo/TodoApplication.java
@@ -1,0 +1,11 @@
+package com.example.todo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class TodoApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(TodoApplication.class, args);
+    }
+}

--- a/backend/src/main/java/com/example/todo/controller/TodoController.java
+++ b/backend/src/main/java/com/example/todo/controller/TodoController.java
@@ -1,0 +1,39 @@
+package com.example.todo.controller;
+
+import com.example.todo.model.Todo;
+import com.example.todo.repository.TodoRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/todos")
+@CrossOrigin(origins = "*")
+public class TodoController {
+    private final TodoRepository repository;
+
+    public TodoController(TodoRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<Todo> all() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    public Todo create(@RequestBody Todo todo) {
+        return repository.save(todo);
+    }
+
+    @PutMapping("/{id}")
+    public Todo update(@PathVariable Long id, @RequestBody Todo todo) {
+        todo.setId(id);
+        return repository.save(todo);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/backend/src/main/java/com/example/todo/model/Todo.java
+++ b/backend/src/main/java/com/example/todo/model/Todo.java
@@ -1,0 +1,45 @@
+package com.example.todo.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Todo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String description;
+    private boolean completed;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public void setCompleted(boolean completed) {
+        this.completed = completed;
+    }
+}

--- a/backend/src/main/java/com/example/todo/repository/TodoRepository.java
+++ b/backend/src/main/java/com/example/todo/repository/TodoRepository.java
@@ -1,0 +1,7 @@
+package com.example.todo.repository;
+
+import com.example.todo.model.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:todo-db
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo App</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        li { margin-bottom: .5em; }
+        input[type=text] { padding: .5em; margin-right: .5em; }
+    </style>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel">
+function App() {
+    const [todos, setTodos] = React.useState([]);
+    const [title, setTitle] = React.useState("");
+    const [description, setDescription] = React.useState("");
+
+    const loadTodos = () => {
+        axios.get('/api/todos').then(r => setTodos(r.data));
+    };
+
+    React.useEffect(loadTodos, []);
+
+    const addTodo = () => {
+        axios.post('/api/todos', { title, description, completed: false })
+             .then(() => { setTitle(""); setDescription(""); loadTodos(); });
+    };
+
+    const deleteTodo = (id) => {
+        axios.delete(`/api/todos/${id}`).then(loadTodos);
+    };
+
+    const toggleTodo = (todo) => {
+        axios.put(`/api/todos/${todo.id}`, { ...todo, completed: !todo.completed })
+             .then(loadTodos);
+    };
+
+    return (
+        <div>
+            <h1>Todo List</h1>
+            <div>
+                <input value={title} placeholder="Title" onChange={e => setTitle(e.target.value)} />
+                <input value={description} placeholder="Description" onChange={e => setDescription(e.target.value)} />
+                <button onClick={addTodo}>Add</button>
+            </div>
+            <ul>
+                {todos.map(todo => (
+                    <li key={todo.id}>
+                        <span style={{ textDecoration: todo.completed ? 'line-through' : 'none' }}>
+                            {todo.title} - {todo.description}
+                        </span>
+                        <button onClick={() => toggleTodo(todo)}>
+                            {todo.completed ? 'Undo' : 'Complete'}
+                        </button>
+                        <button onClick={() => deleteTodo(todo.id)}>Delete</button>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement Spring Boot backend with CRUD endpoints for todos
- add simple React frontend using CDN libraries
- document build and usage steps

## Testing
- `mvn -q package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6849998f6a98833392570dbfdc566a9c